### PR TITLE
Fixing a startup issue related to the log.format option.

### DIFF
--- a/SOURCES/environment.conf
+++ b/SOURCES/environment.conf
@@ -5,9 +5,10 @@ Environment="WEB_ADDR=0.0.0.0:9100"
 # Path under which to expose metrics. (default "/metrics")
 Environment="TELEMETRY_PATH=/metrics"
 
-# Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true" (default "logger:stderr")
-# Send to syslog at local2 facility: SYSLOG_CONF=logger:syslog?appname=prometheus-node-exporter&local=2
-Environment="SYSLOG_CONF=logger:stderr"
+# Set the log format. Default is logfmt.
+# Valid values: [logfmt, json]
+# Examples for versions < 1.0.0: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true" (default "logger:stderr")
+Environment="SYSLOG_CONF=RPM_LOG_FORMAT"
 
 # Set logging level. Default is info. Only log messages with the given severity or above.
 # Valid levels: [debug, info, warn, error, fatal]


### PR DESCRIPTION
Hello! I stumbled upon your project while considering different approaches for managing node_exporter instances. The changes below represent the modifications that were required in order to successfully start the service for versions of node_exporter >= 1.0.0. Let me know if you have any comments or concerns.

Tested with CS9 + v0.18.1/v1.0.0/v1.9.0.