### PR TITLE
feat: add multi-architecture build support.

### DIFF
--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -7,13 +7,14 @@ Summary:        Prometheus exporter for machine metrics.
 License:        ASL 2.0
 URL:            https://prometheus.io
 
-Source0:        node_exporter-%{pkg_version}.linux-amd64.tar.gz
+Source0:        node_exporter-%{pkg_version}.linux-%{product_arch}.tar.gz
 Source1:        %{name}.service
 Source2:        logrotate.conf
 Source3:        rsyslog.conf
 Source4:        environment.conf
 
 BuildRoot:      %{buildroot}
+BuildArch:      %{build_arch}
 BuildRequires:  systemd-units
 Requires:       systemd, logrotate, rsyslog > 7.2
 Requires(pre):  shadow-utils
@@ -27,7 +28,7 @@ results, and can trigger alerts if some condition is observed to be true.
 This package contains binary to export node metrics to prometheus.
 
 %prep
-%setup -q -n node_exporter-%{version}.linux-amd64
+%setup -q -n node_exporter-%{version}.linux-%{product_arch}
 
 %install
 # 0.15.0 = 0*50^2+15*50^1+0*50^0 = 750. See version_to_number()

--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -1,3 +1,5 @@
+%global debug_package %{nil}
+
 Name:           prometheus-node-exporter
 Version:        %{pkg_version}
 Release:        %{rpm_release}%{?dist}
@@ -12,7 +14,6 @@ Source3:        rsyslog.conf
 Source4:        environment.conf
 
 BuildRoot:      %{buildroot}
-BuildArch:      x86_64
 BuildRequires:  systemd-units
 Requires:       systemd, logrotate, rsyslog > 7.2
 Requires(pre):  shadow-utils

--- a/build.sh
+++ b/build.sh
@@ -314,4 +314,4 @@ download_packages
 # _topdir and _tmppath are magic rpm variables that can be defined in ~/.rpmmacros
 # For ease of reliable builds they are defined here on the command line.
 print_debug_line "Starting rpmbuild."
-rpmbuild -ba --define="_topdir $build_root" --define="buildroot $build_root/BUILDROOT" --define="pkg_version $pkg_version" --define="rpm_release $pkg_release" --target "$rpm_arch" $build_root/SPECS/$product.spec
+rpmbuild -ba --define="_topdir $build_root" --define="buildroot $build_root/BUILDROOT" --define="pkg_version $pkg_version" --define="rpm_release $pkg_release" --define="product_arch $product_arch" --define="build_arch $rpm_arch" --target "$rpm_arch" $build_root/SPECS/$product.spec

--- a/build.sh
+++ b/build.sh
@@ -165,33 +165,6 @@ function perform_safety_checks()
     fi
 }
 
-function validate_inputs()
-{
-    # Check if correct version has been supplied. Otherwise downloads will fail.
-    [ ${#available_versions[@]} -eq 0 ] && get_available_versions
-
-    is_version_valid='false'
-    if [ "$pkg_version" == "latest" ]; then
-        pkg_version=$(echo ${!available_versions[@]} | tr ' ' '\n' | sort --version-sort | tail -n 1)
-        is_version_valid='true'
-    else
-        for available_version in ${!available_versions[@]}; do
-            if [ "$available_version" == "$pkg_version" ]; then
-                is_version_valid='true'
-                break
-            fi
-        done
-    fi
-
-    if [ "$is_version_valid" == 'false' ]; then
-        echo "'$pkg_version' of $product is not available upstream. Versions available for packaging:"
-        print_available_versions
-        exit 6
-    fi
-
-    print_debug_line "Using version: $pkg_version"
-}
-
 function detect_arch_and_os() {
     if [ -z "$target_arch" ]; then
         target_arch=$(uname -m)
@@ -222,6 +195,33 @@ function detect_arch_and_os() {
     fi
 
     print_debug_line "Final Architectures -> Raw: $raw_arch | RPM: $rpm_arch | Product: $product_arch"
+}
+
+function validate_inputs()
+{
+    # Check if correct version has been supplied. Otherwise downloads will fail.
+    [ ${#available_versions[@]} -eq 0 ] && get_available_versions
+
+    is_version_valid='false'
+    if [ "$pkg_version" == "latest" ]; then
+        pkg_version=$(echo ${!available_versions[@]} | tr ' ' '\n' | sort --version-sort | tail -n 1)
+        is_version_valid='true'
+    else
+        for available_version in ${!available_versions[@]}; do
+            if [ "$available_version" == "$pkg_version" ]; then
+                is_version_valid='true'
+                break
+            fi
+        done
+    fi
+
+    if [ "$is_version_valid" == 'false' ]; then
+        echo "'$pkg_version' of $product is not available upstream. Versions available for packaging:"
+        print_available_versions
+        exit 6
+    fi
+
+    print_debug_line "Using version: $pkg_version"
 }
 
 function get_available_versions()
@@ -301,9 +301,9 @@ function download_packages()
 # Pass all args of the script to the function.
 parse_command "$@"
 perform_safety_checks
-validate_inputs
 # Get the architecture code of the current execution build.
 detect_arch_and_os
+validate_inputs
 for func in ${execute_features[@]}; do
     ($func)
 done


### PR DESCRIPTION
Refactor the build script and spec file to support dynamic architecture detection and cross-platform packaging.

- Replace hardcoded 'x86_64' with dynamic architecture detection
- Add '-a/--arch' flag to allow manual target specification
- Update rpmbuild command to use '--target' for cross-packaging