### PR TITLE
feat: Add CI build supports.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -185,7 +185,7 @@ function perform_safety_checks()
     done
 
     # The container environment does not have Systemd, so this part will be missing.
-    if [ "$(rpm --eval '%systemd_post')" == "%systemd_post" ]; then
+    if [ "$(rpm --eval '%systemd_post' 2>/dev/null)" == "%systemd_post" ]; then
         print_debug_line "${FUNCNAME[0]} : Systemd RPM macros are missing."
         if grep -q "release 7" /etc/redhat-release 2>/dev/null; then
             sys_pkg="systemd"


### PR DESCRIPTION
This PR adjusts the build script to ensure smooth execution in CI environments. Key changes include:
- Allow root execution in CI: Recognized that CI pipelines are controlled environments (e.g., containers), so the script now permits running as root without strict user checks.
- Refactor OS detection: Switched from reading /proc/version to parsing the /etc/os-release file. This fixes detection issues in containerized environments where /proc/version reflects the host kernel rather than the container's distribution.

These changes ensure the script runs reliably within CI/CD pipelines.