### PR TITLE
streamline arch detection. make script container friendly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Code to package various versions of Prometheus project's node_exporter with mini
 
 ## Pre-requisites
 
-* RedHat or its derivatives like CentOS.
+* RedHat or its derivatives like RockyLinux.
 * Network connection to public internet to reach repositories and github.
 
 ## Limitations
 
-* Script has been only tested on CentOS 7 to package latest available node_exporter. Please feel free to make pull requests if you want to add more nuanced support for older versions.
+* Script has been only tested on AmazonLinux 2023, Fedora 43 & RockyLinux 8 containers to package latest available node_exporter. Please feel free to make pull requests if you want to add more nuanced support for older versions.
 * No guarantees are being made for fitness of purpose or merchantabilities. Any results of usage of work herein is not author's or contributor's responsibility.
 
 ## Usage

--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -13,6 +13,7 @@ Source4:        environment.conf
 
 BuildRoot:      %{buildroot}
 BuildArch:      %{build_arch}
+BuildRequires:  (systemd or systemd-rpm-macros)
 Requires:       systemd, logrotate, rsyslog > 7.2
 Requires(pre):  shadow-utils
 
@@ -149,7 +150,7 @@ echo
 * Mon Dec 15 2025 lam827@lamgc.net
 - Added support for more architectures in addition to x86_64.
 
-* Sun Feb 04 2019 talk@devghai.com
+* Mon Feb 04 2019 talk@devghai.com
 - Added support for handling breaking changes introduced in 0.15.0.
 
 * Tue May 23 2017 talk@devghai.com

--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -1,5 +1,3 @@
-%global debug_package %{nil}
-
 Name:           prometheus-node-exporter
 Version:        %{pkg_version}
 Release:        %{rpm_release}%{?dist}
@@ -148,6 +146,9 @@ echo
 /usr/share/prometheus/node_exporter/LICENSE
 
 %changelog
+
+* Mon Dec 15 2025 lam827@lamgc.net
+- Added support for more architectures in addition to x86_64.
 
 * Sun Feb 04 2019 talk@devghai.com
 - Added support for handling breaking changes introduced in 0.15.0.

--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -13,7 +13,7 @@ Source4:        environment.conf
 
 BuildRoot:      %{buildroot}
 BuildArch:      %{build_arch}
-BuildRequires:  (systemd or systemd-rpm-macros)
+BuildRequires:  (systemd-units or systemd-rpm-macros)
 Requires:       systemd, logrotate, rsyslog > 7.2
 Requires(pre):  shadow-utils
 

--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -146,14 +146,16 @@ echo
 /usr/share/prometheus/node_exporter/LICENSE
 
 %changelog
+* Fri Dec 19 2025 github@gimme.email
+- Make build script container friendly.
 
 * Mon Dec 15 2025 lam827@lamgc.net
 - Added support for more architectures in addition to x86_64.
 
-* Mon Feb 04 2019 talk@devghai.com
+* Mon Feb 04 2019 github@gimme.email
 - Added support for handling breaking changes introduced in 0.15.0.
 
-* Tue May 23 2017 talk@devghai.com
+* Tue May 23 2017 github@gimme.email
 - Initial release for packaging Prometheus's Node Exporter.
   See https://github.com/meowtochondria/node_exporter-rpm/blob/master/README.md.
 

--- a/SPECS/node_exporter.spec
+++ b/SPECS/node_exporter.spec
@@ -13,7 +13,6 @@ Source4:        environment.conf
 
 BuildRoot:      %{buildroot}
 BuildArch:      %{build_arch}
-BuildRequires:  systemd-units
 Requires:       systemd, logrotate, rsyslog > 7.2
 Requires(pre):  shadow-utils
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 ###########################################
 # Some initializations.                   #
@@ -13,7 +13,10 @@ build_root=$(realpath $current_dir/rpmbuild)
 download_url_root="https://github.com/$project/$product/releases/download/"
 release_link="https://api.github.com/repos/$project/$product/releases"
 execute_features=()
-target_arch=''
+target_arch='x86_64'
+product_arch='amd64'
+rpm_arch="$target_arch"
+bypass_root_check="false"
 declare -A available_versions
 
 # Array containing mapping of dependency binaries to the packages that contain them.
@@ -24,7 +27,7 @@ deps_bin_to_pkg=(
     ['wget']='wget'
     ['rpmbuild']='rpm-build'
     ['sha256sum']='coreutils'
-    ['curl']='curl'
+    ['getopt']='util-linux'
 )
 ###########################################
 # Functions                               #
@@ -38,32 +41,39 @@ function print_debug_line()
 
 function usage()
 {
-    echo "Script to setup RPM build environment and package $product.";
-    echo "The script should _NOT_ be run as root. It will ask for";
-    echo "password via sudo if something needs it.";
-    echo "";
-    echo "Usage: ${0} [-v version_to_build] [-r release_version]";
-    echo -e "\n-v\tVersion of $product to build. This version should be";
-    echo -e "  \tavailable upstream. Default: latest ($pkg_version)";
+    echo "Script to setup RPM build environment and package $product."
+    echo "Only linux is supported."
+    echo ""
+    echo "The script should _NOT_ be run as root. It will ask for"
+    echo "password via sudo if something needs it."
+    echo ""
+    echo "Usage: ${0} [-v version_to_build] [-r release_version]"
+    echo -e "\n-v\tVersion of $product to build. This version should be"
+    echo -e "  \tavailable upstream. Default: latest ($pkg_version)"
     echo -e "\n-r\tRPM release version. Use this field to specify if this is a"
     echo -e "  \tcustom version for your needs. For example, if you are"
     echo -e "  \tbuilding this package for your company, you can set this"
-    echo -e "  \tto company name. Default: 1";
-    echo -e "\n-b\tPath that will contain RPM build tree. Default is current dir.";
-    echo -e "\n-l\tList available versions.";
-    echo -e "\n-h\tShow this help message and exit.";
-    echo -e "\n-d\tPrint debugging statements.";
-    echo -e "\nExample: ${0} -v $pkg_version";
+    echo -e "  \tto company name. Default: 1"
+    echo -e "\n-b\tPath that will contain RPM build tree. Default is current dir."
+    echo -e "\n-a\tTarget CPU architecture. Appropriate upstream package will be"
+    echo -e "  \tdetected automatically. Default: $target_arch"
+    echo -e "\n-t\tBypass root check. NOT RECOMMENDED. Useful when running inside"
+    echo -e "  \tcontainers where only root is available."
+    echo -e "\n-l\tList available versions."
+    echo -e "\n-h\tShow this help message and exit."
+    echo -e "\n-d\tPrint debugging statements."
+    echo -e "\nExample: ${0} -v $pkg_version"
 }
 
 function parse_command()
 {
-    SHORT=v:r:b:a:lhd
-    LONG=version:,release:,build_root:,arch:,list,help,debug
+    SHORT=v:r:b:a:tlhd
+    LONG=version:,release:,build-root:,arch:,bypass-root-check,list,help,debug
     PARSED=$(getopt --options $SHORT --longoptions $LONG --name "$0" -- "$@")
     if [[ $? -ne 0 ]]; then
         # e.g. $? == 1
         #  then getopt has complained about wrong arguments to stdout
+        echo "Parsing arguments failed. Is ${deps_bin_to_pkg[getopt]} installed?"
         exit 1
     fi
 
@@ -86,13 +96,17 @@ function parse_command()
                 pkg_release="$2"
                 shift 2
                 ;;
-            -b|--build_root)
+            -b|--build-root)
                 build_root="$2"
                 shift 2
                 ;;
             -a|--arch)
                 target_arch="$2"
                 shift 2
+                ;;
+            -t|--bypass-root-check)
+                bypass_root_check="true"
+                shift
                 ;;
             -l|--list)
                 execute_features+=('print_available_versions')
@@ -114,34 +128,12 @@ function parse_command()
     done
 }
 
-function perform_safety_checks()
+function ensure_dependencies()
 {
-    # Ensure we are not running as root.
-    if [ $EUID -eq 0 ]; then
-        echo 'Please do not run this script as root.'
-        echo 'See https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Preparing_your_system for details.'
-        exit 3
-    fi
-
-    # Ensure we are on Red Hat or its derivatives.
-    if [ -f "/proc/version" ]; then
-        proc_version=`cat /proc/version`
-    else
-        proc_version=`uname -a`
-    fi
-
-    print_debug_line "${FUNCNAME[0]} : proc version = $proc_version"
-
-    if [[ $proc_version != *"Red Hat"* ]]; then
-        echo "ERROR: Your OS is not supported by this script! :("
-        echo "At the moment only Red Hat and its derivatives are supported."
-        exit 4
-    fi
-
     # Check if packages are installed
     unavailable_packages=''
     for dep in ${!deps_bin_to_pkg[@]}; do
-        which $dep &>/dev/null
+        command -v $dep &>/dev/null
         if [ "$?" -gt 0 ]; then
             print_debug_line "${FUNCNAME[0]} : '$dep' from '${deps_bin_to_pkg[$dep]}' is not installed."
             unavailable_packages+="${deps_bin_to_pkg[$dep]} "
@@ -165,36 +157,52 @@ function perform_safety_checks()
     fi
 }
 
-function detect_arch_and_os() {
-    if [ -z "$target_arch" ]; then
-        target_arch=$(uname -m)
+function perform_safety_checks()
+{
+    # Ensure we are not running as root.
+    if [ $EUID -eq 0 ] && [ $bypass_root_check = "false" ]; then
+        echo 'Please do not run this script as root.'
+        echo 'See https://fedoraproject.org/wiki/How_to_create_an_RPM_package#Preparing_your_system for details.'
+        exit 3
     fi
-    
-    raw_arch="$target_arch"
 
-    case "$raw_arch" in
+    # Ensure we are on Red Hat or its derivatives.
+    if [ -f "/etc/os-release" ]; then
+        proc_version=$(grep -E '^ID=' /etc/os-release | cut -f 2 -d '=')
+    else
+        proc_version=$(uname -a)
+    fi
+
+    print_debug_line "${FUNCNAME[0]} : proc version = $proc_version"
+
+    if [[ $proc_version != *"Red Hat"* ]] && [[ $proc_version != *"fedora"* ]] && [[ $proc_version != *"centos"* ]]; then
+        echo "ERROR: Your OS is not supported by this script! :("
+        echo "At the moment only Red Hat and its derivatives are supported."
+        exit 4
+    fi
+}
+
+function map_cpu_arch_to_product_arch() {
+    # Determine what package maps to upstream as it slightly deviates from what RPM likes.
+    # TODO: Verify if this switch case and capture from /usr/lib/rpm/rpmrc is enough to triangulate upstream builds.
+    case "$target_arch" in
         x86_64)          product_arch="amd64" ;;
         aarch64)         product_arch="arm64" ;;
         armv7l|armv7hl)  product_arch="armv7" ;;
-        riscv64)         product_arch="riscv64" ;;
-        ppc64le)         product_arch="ppc64le" ;;
-        s390x)           product_arch="s390x" ;;
         i686|i386)       product_arch="386" ;;
-        *)               product_arch="$raw_arch" ;;
+        *)               product_arch="$target_arch" ;;
     esac
 
-    rpm_arch="$raw_arch"
-
     if [ -f /usr/lib/rpm/rpmrc ]; then
-        translated_arch=$(grep "^buildarchtranslate: $raw_arch:" /usr/lib/rpm/rpmrc | awk '{print $3}')
+        translated_arch=$(grep "buildarchtranslate: ${target_arch}:" /usr/lib/rpm/rpmrc | cut -f 3 -d ' ')
         
         if [ -n "$translated_arch" ]; then
-            print_debug_line "Found architecture translation in rpmrc: $raw_arch -> $translated_arch"
+            print_debug_line "${FUNCNAME[0]} : Found architecture translation in rpmrc: $target_arch -> $translated_arch"
             rpm_arch="$translated_arch"
         fi
     fi
 
-    print_debug_line "Final Architectures -> Raw: $raw_arch | RPM: $rpm_arch | Product: $product_arch"
+    print_debug_line "${FUNCNAME[0]} : Final Architectures -> Raw: $target_arch | RPM: $rpm_arch | Product: $product_arch"
 }
 
 function validate_inputs()
@@ -226,8 +234,10 @@ function validate_inputs()
 
 function get_available_versions()
 {
-    print_debug_line "Getting available versions from $release_link"
-    links=$(curl --silent $release_link | grep -oP "https.+$product-\d+\.\d+\.\d+\.linux-$product_arch.tar.gz")
+    map_cpu_arch_to_product_arch
+
+    print_debug_line "${FUNCNAME[0]} : Getting available versions from $release_link"
+    links=$(wget $release_link -O - | grep -oP "https.+$product-\d+\.\d+\.\d+\.linux-$product_arch.tar.gz")
     if [ "$?" -ne 0 ]; then
         echo "Could not fetch releases from $release_link."
         echo "Please verify you are connected to the interwebz."
@@ -237,6 +247,7 @@ function get_available_versions()
     for link in $links; do
         ver=$(echo $link | cut -f 8 -d '/' | tr -d 'v')
         available_versions["$ver"]=$link
+        print_debug_line "${FUNCNAME[0]} : $ver = $link"
     done
 }
 
@@ -273,7 +284,7 @@ function download_packages()
 
     # Skip download if file already exists
     if [ -f "$sources_dir/$core_archive_name" ]; then
-        print_debug_line "$sources_dir/$core_archive_name already exists. Not downloading again..."
+        print_debug_line "${FUNCNAME[0]} : $sources_dir/$core_archive_name already exists. Not downloading again..."
         return
     fi
 
@@ -298,20 +309,30 @@ function download_packages()
 }
 
 ##################
+# Ensure all packages are available as some OS images even lack getopt package.
+ensure_dependencies
+
 # Pass all args of the script to the function.
 parse_command "$@"
-perform_safety_checks
-# Get the architecture code of the current execution build.
-detect_arch_and_os
-validate_inputs
 for func in ${execute_features[@]}; do
     ($func)
 done
 [ ${#execute_features[@]} -gt 0 ] && exit 0
+
+perform_safety_checks
+validate_inputs
 setup_rpm_tree
 download_packages
 # Now that the sources are downloaded and verified we can actually make the RPM.
 # _topdir and _tmppath are magic rpm variables that can be defined in ~/.rpmmacros
 # For ease of reliable builds they are defined here on the command line.
 print_debug_line "Starting rpmbuild."
+
+print_debug_line "rpmbuild -ba --define=\"_topdir $build_root\" --define=\"buildroot $build_root/BUILDROOT\" --define=\"pkg_version $pkg_version\" --define=\"rpm_release $pkg_release\" --define=\"product_arch $product_arch\" --define=\"build_arch $rpm_arch\" --target \"$rpm_arch\" $build_root/SPECS/$product.spec"
+
+# TODO: rpmbuild is failing silently.
 rpmbuild -ba --define="_topdir $build_root" --define="buildroot $build_root/BUILDROOT" --define="pkg_version $pkg_version" --define="rpm_release $pkg_release" --define="product_arch $product_arch" --define="build_arch $rpm_arch" --target "$rpm_arch" $build_root/SPECS/$product.spec
+
+# rpmbuild -ba --define="_topdir /src/rpmbuild" --define="buildroot /src/rpmbuild/BUILDROOT" --define="pkg_version 1.10.2" --define="rpm_release 1" --define="product_arch amd64" --define="build_arch x86_64" --target "x86_64" --verbose /src/rpmbuild/SPECS/node_exporter.spec
+
+# rpmbuild -ba --define="_topdir /src/rpmbuild" --define="buildroot /src/rpmbuild/BUILDROOT" --define="pkg_version 1.10.2" --define="rpm_release 1" --define="product_arch amd64" --define="build_arch x86_64" /src/rpmbuild/SPECS/node_exporter.spec

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 ###########################################
 # Some initializations.                   #
@@ -328,11 +328,6 @@ download_packages
 # For ease of reliable builds they are defined here on the command line.
 print_debug_line "Starting rpmbuild."
 
-print_debug_line "rpmbuild -ba --define=\"_topdir $build_root\" --define=\"buildroot $build_root/BUILDROOT\" --define=\"pkg_version $pkg_version\" --define=\"rpm_release $pkg_release\" --define=\"product_arch $product_arch\" --define=\"build_arch $rpm_arch\" --target \"$rpm_arch\" $build_root/SPECS/$product.spec"
+print_debug_line "rpmbuild --nodebuginfo --verbose -ba --define=\"_topdir $build_root\" --define=\"buildroot $build_root/BUILDROOT\" --define=\"pkg_version $pkg_version\" --define=\"rpm_release $pkg_release\" --define=\"product_arch $product_arch\" --define=\"build_arch $rpm_arch\" --define=\"_unitdir /usr/lib/systemd/system\" $build_root/SPECS/$product.spec"
 
-# TODO: rpmbuild is failing silently.
-rpmbuild -ba --define="_topdir $build_root" --define="buildroot $build_root/BUILDROOT" --define="pkg_version $pkg_version" --define="rpm_release $pkg_release" --define="product_arch $product_arch" --define="build_arch $rpm_arch" --target "$rpm_arch" $build_root/SPECS/$product.spec
-
-# rpmbuild -ba --define="_topdir /src/rpmbuild" --define="buildroot /src/rpmbuild/BUILDROOT" --define="pkg_version 1.10.2" --define="rpm_release 1" --define="product_arch amd64" --define="build_arch x86_64" --target "x86_64" --verbose /src/rpmbuild/SPECS/node_exporter.spec
-
-# rpmbuild -ba --define="_topdir /src/rpmbuild" --define="buildroot /src/rpmbuild/BUILDROOT" --define="pkg_version 1.10.2" --define="rpm_release 1" --define="product_arch amd64" --define="build_arch x86_64" /src/rpmbuild/SPECS/node_exporter.spec
+rpmbuild --nodebuginfo --verbose -ba --define="_topdir $build_root" --define="buildroot $build_root/BUILDROOT" --define="pkg_version $pkg_version" --define="rpm_release $pkg_release" --define="product_arch $product_arch" --define="build_arch $rpm_arch" --define="_unitdir /usr/lib/systemd/system" $build_root/SPECS/$product.spec

--- a/build.sh
+++ b/build.sh
@@ -141,11 +141,16 @@ function ensure_dependencies()
         print_debug_line "${FUNCNAME[0]} : $dep is available."
     done
 
+    SUDO='sudo'
+    if [ $EUID -eq 0 ] && [ $bypass_root_check = "false" ]; then
+        SUDO=''
+    fi
+
     # Install missing packages. Exit if installation is unsuccessful.
     if [ -n "$unavailable_packages" ]; then
         echo -e "\nFollowing packages need to be installed:\n$unavailable_packages"
         echo    "Please enter the password for sudo (if prompted)"
-        sudo yum install -y $unavailable_packages
+        $SUDO yum install -y $unavailable_packages
 
         # Check if installation was successful.
         if [ "$?" -ne 0 ]; then
@@ -168,14 +173,14 @@ function perform_safety_checks()
 
     # Ensure we are on Red Hat or its derivatives.
     if [ -f "/etc/os-release" ]; then
-        proc_version=$(grep -E '^ID=' /etc/os-release | cut -f 2 -d '=')
+        proc_version=$(grep -E '^ID=' /etc/os-release | cut -f 2 -d '=' | tr -d '"')
     else
         proc_version=$(uname -a)
     fi
 
     print_debug_line "${FUNCNAME[0]} : proc version = $proc_version"
 
-    if [[ $proc_version != *"Red Hat"* ]] && [[ $proc_version != *"fedora"* ]] && [[ $proc_version != *"centos"* ]]; then
+    if [[ $proc_version != *"Red Hat"* ]] && [[ $proc_version != *"fedora"* ]] && [[ $proc_version != *"centos"* ]] && [[ $proc_version != *"rocky"* ]] && [[ $proc_version != *"amzn"* ]]  && [[ $proc_version != *"rhel"* ]]; then
         echo "ERROR: Your OS is not supported by this script! :("
         echo "At the moment only Red Hat and its derivatives are supported."
         exit 4

--- a/build.sh
+++ b/build.sh
@@ -182,7 +182,6 @@ function ensure_supported_env()
 
 function map_cpu_arch_to_product_arch() {
     # Determine what package maps to upstream as it slightly deviates from what RPM likes.
-    # TODO: Verify if this switch case and capture from /usr/lib/rpm/rpmrc is enough to triangulate upstream builds.
     case "$target_arch" in
         x86_64|ia32e)               product_arch="amd64" ;;
         aarch64)                    product_arch="arm64" ;;
@@ -226,7 +225,7 @@ function validate_inputs()
     fi
 
     if [ "$is_version_valid" == 'false' ]; then
-        echo "'$pkg_version' of $product is not available upstream. Versions available for packaging:"
+        echo "'$pkg_version' of $product with arch $target_arch is not available upstream. Versions available for packaging:"
         print_available_versions
         exit 6
     fi
@@ -243,6 +242,7 @@ function get_available_versions()
     if [ "$?" -ne 0 ]; then
         echo "Could not fetch releases from $release_link."
         echo "Please verify you are connected to the interwebz."
+        echo "Or $target_arch ($product_arch) may not be availble upstream."
         echo "Exiting..."
         exit 7
     fi


### PR DESCRIPTION
* Added translation from CPU arch to package arch available upstream to allow cross compilation.
* Support for executing inside containers:
    * Made root check a warning, and not exiting anymore. Most containers ate setup with `root` user only, so that check was not helpful.
    * `getopt` package is installed as it is not available in most containers out-of-the-box.
    * Tested generating RPM on a bunch of redhat derivatives.

Podman command for testing:
```
podman run --attach stderr --attach stdout --interactive --volume $HOME/src/node_exporter-rpm:/src docker.io/library/amazonlinux:latest /bin/sh
```
You can find images using
```
podman search almalinux
```
and plug it into above command.