### PR TITLE
feat: authenticate to github.com if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Code to package various versions of Prometheus project's node_exporter with mini
 
 * RedHat or its derivatives like RockyLinux.
 * Network connection to public internet to reach repositories and github.
+* If access to github.com is rate limited, please provide GitHub access token in the `GITHUB_TOKEN` environment variable.
 
 ## Limitations
 

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,6 @@ pkg_release='1'
 isDebug=false
 current_dir=$(dirname ${0})
 build_root=$(realpath $current_dir/rpmbuild)
-download_url_root="https://github.com/$project/$product/releases/download/"
 release_link="https://api.github.com/repos/$project/$product/releases"
 execute_features=()
 target_arch='x86_64'

--- a/build.sh
+++ b/build.sh
@@ -245,9 +245,9 @@ function get_available_versions()
     )
     if [ "$?" -ne 0 ]; then
         echo "Could not fetch releases from $release_link."
-        echo "Please verify you are connected to the interwebz."
-        echo "Or $target_arch ($product_arch) may not be availble upstream."
-        echo "You might also need to set GITHUB_TOKEN to login to github.com."
+        echo " * The connection to the public internet might be not working"
+        echo " * There is no build for $target_arch ($product_arch) available upstream"
+        echo " * github.com might require authentication - in that case please set GITHUB_TOKEN environment variable"
         echo "Exiting..."
         exit 7
     fi

--- a/build.sh
+++ b/build.sh
@@ -246,7 +246,7 @@ function get_available_versions()
         exit 7
     fi
     for link in $links; do
-        ver=$(echo $link | cut -f 8 -d '/' | tr -d 'v')
+        ver=$(echo "$link" | cut -f 8 -d '/' | tr -d 'v')
         available_versions["$ver"]=$link
         print_debug_line "${FUNCNAME[0]} : $ver = $link"
     done
@@ -257,7 +257,7 @@ function print_available_versions()
     echo "Released versions available upstream..."
     [ ${#available_versions[@]} -eq 0 ] && get_available_versions
     # Reference: http://www.tldp.org/LDP/abs/html/arrays.html
-    echo ${!available_versions[@]} | tr -s ' ' '\n' | sort --version-sort --reverse
+    echo "${!available_versions[@]}" | tr -s ' ' '\n' | sort --version-sort --reverse
 }
 
 function setup_rpm_tree()
@@ -279,22 +279,22 @@ function setup_rpm_tree()
 function download_packages()
 {
     # prometheus is not publishing checksums for every release :/
-    core_archive_name=$(basename ${available_versions[$pkg_version]})
-    sources_dir="$build_root/SOURCES"
+    core_archive_name=$(basename "${available_versions[$pkg_version]}")
+    sources_dir="${build_root:?}/SOURCES"
     failed_download='false'
 
     # Skip download if file already exists
-    if [ -f "$sources_dir/$core_archive_name" ]; then
+    if [ -f "${sources_dir}/${core_archive_name}" ]; then
         print_debug_line "${FUNCNAME[0]} : $sources_dir/$core_archive_name already exists. Not downloading again..."
         return
     fi
 
     print_debug_line "${FUNCNAME[0]} : Downloading ${available_versions[$pkg_version]} to $sources_dir/$core_archive_name"
-    wget -O $sources_dir/$core_archive_name ${available_versions[$pkg_version]}
+    wget -O "${sources_dir}/${core_archive_name}" "${available_versions[$pkg_version]}"
 
     # Print a message if download leads to file of size 0, or wget exits with
     # non-zero exit code
-    if [ ! -s $sources_dir/$core_archive_name -o "$?" -ne 0 ]; then
+    if [ ! -s "${sources_dir}/${core_archive_name}" -o "$?" -ne 0 ]; then
         echo
         echo "Failed to download ${available_versions[$pkg_version]}."
         echo "Please verify if the link is accurate and network connectivity"


### PR DESCRIPTION
If access to github.com is rate limited (for example behind
a large corporate proxy), it is now possible to set GITHUB_TOKEN
environment variable to authenticate and skip rate limiting.